### PR TITLE
Allow managers to create stores when adding supervisors

### DIFF
--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -161,7 +161,7 @@ const options = {
         },
         CreateSupervisorRequest: {
           type: 'object',
-          required: ['phone', 'password', 'name', 'storeId'],
+          required: ['phone', 'password', 'name'],
           properties: {
             phone: {
               type: 'string',
@@ -183,7 +183,42 @@ const options = {
             storeId: {
               type: 'string',
               format: 'uuid',
+              description: 'Provide this when assigning the supervisor to an existing store',
               example: '11111111-1111-1111-1111-111111111111',
+            },
+            store: {
+              type: 'object',
+              description: 'Provide this object to create a brand new store for the supervisor',
+              properties: {
+                name: {
+                  type: 'string',
+                  minLength: 2,
+                  maxLength: 100,
+                  example: 'Central Store',
+                },
+                address: {
+                  type: 'string',
+                  nullable: true,
+                  example: '123 Main Street, City Center',
+                },
+                phone: {
+                  type: 'string',
+                  nullable: true,
+                  minLength: 10,
+                  maxLength: 20,
+                  example: '080123456789',
+                },
+                email: {
+                  type: 'string',
+                  nullable: true,
+                  example: 'central@store.com',
+                },
+                isActive: {
+                  type: 'boolean',
+                  nullable: true,
+                  example: true,
+                },
+              },
             },
           },
         },


### PR DESCRIPTION
## Summary
- allow supervisor creation requests to provide either an existing store id or a payload for a brand new store
- create a store within the manager service transaction when store details are supplied and attach it to the supervisor response
- document the updated supervisor creation contract in the Swagger schema

## Testing
- npm install *(fails: 403 Forbidden fetching doctrine-2.1.0.tgz from npm registry)*
- npm run lint *(fails: global ESLint 9.x requires new config because project dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfa372fa08326a9d704fd15bd807f