### PR TITLE
Generate store IDs for new supervisor stores

### DIFF
--- a/src/controllers/manager.controller.js
+++ b/src/controllers/manager.controller.js
@@ -1,4 +1,5 @@
 const { body } = require('express-validator');
+const { v4: uuidv4 } = require('uuid');
 const managerService = require('../services/manager.service');
 const response = require('../utils/response');
 const { handleValidationErrors } = require('../middlewares/validate');
@@ -35,13 +36,14 @@ const createSupervisorValidation = [
     .isUUID()
     .withMessage('Store ID must be a valid UUID'),
   body().custom((_, { req }) => {
-    const { storeId, store } = req.body;
+    const originalStoreId = req.body.storeId;
+    const { store } = req.body;
 
-    if (!storeId && !store) {
+    if (!originalStoreId && !store) {
       throw new Error('Either storeId or store details must be provided');
     }
 
-    if (storeId && store) {
+    if (originalStoreId && store) {
       throw new Error('Provide either storeId or store details, not both');
     }
 
@@ -57,6 +59,10 @@ const createSupervisorValidation = [
 
       if (name.length < 2 || name.length > 100) {
         throw new Error('Store name must be between 2 and 100 characters');
+      }
+
+      if (!originalStoreId) {
+        req.body.storeId = uuidv4();
       }
 
       if (store.phone) {

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -183,12 +183,12 @@ const options = {
             storeId: {
               type: 'string',
               format: 'uuid',
-              description: 'Provide this when assigning the supervisor to an existing store',
+              description: 'Optional. Provide this only when assigning the supervisor to an existing store. A new UUID will be generated automatically when creating a new store.',
               example: '11111111-1111-1111-1111-111111111111',
             },
             store: {
               type: 'object',
-              description: 'Provide this object to create a brand new store for the supervisor',
+              description: 'Provide this object to create a brand new store for the supervisor. The API will generate the storeId automatically when this is supplied.',
               properties: {
                 name: {
                   type: 'string',


### PR DESCRIPTION
## Summary
- generate store IDs in the manager controller when creating supervisors without an existing store
- persist the generated ID when creating the backing store record and continue validating existing IDs
- clarify in the Swagger docs that new store IDs are created automatically unless referencing an existing store

## Testing
- npm install *(fails: registry returned 403 for doctrine@2.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0c4b4c848326a0f2bc528f8ffdf8