### PR TITLE
Add manager monthly product summary endpoint

### DIFF
--- a/src/controllers/manager.controller.js
+++ b/src/controllers/manager.controller.js
@@ -17,6 +17,28 @@ const getDashboard = async (req, res, next) => {
   }
 };
 
+const getMonthlyProductSummary = async (req, res, next) => {
+  try {
+    const { year: yearQuery } = req.query;
+    const currentYear = new Date().getUTCFullYear();
+
+    let year = currentYear;
+
+    if (typeof yearQuery !== 'undefined' && yearQuery !== '') {
+      const parsedYear = Number(yearQuery);
+      if (!Number.isInteger(parsedYear) || parsedYear < 1900 || parsedYear > 9999) {
+        return res.status(400).json(response.error('Year must be an integer between 1900 and 9999'));
+      }
+      year = parsedYear;
+    }
+
+    const summary = await managerService.getMonthlyProductSummary(year);
+    res.json(response.success('Monthly product summary retrieved successfully', summary));
+  } catch (error) {
+    next(error);
+  }
+};
+
 const createSupervisorValidation = [
   body('phone')
     .notEmpty()
@@ -199,5 +221,6 @@ module.exports = {
   getSupervisors,
   getSalesUsers,
   getProducts,
+  getMonthlyProductSummary,
   handleValidationErrors,
 };

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -374,6 +374,44 @@ const options = {
             },
           },
         },
+        MonthlyProductSummaryResponse: {
+          type: 'object',
+          properties: {
+            success: {
+              type: 'boolean',
+              example: true,
+            },
+            message: {
+              type: 'string',
+              example: 'Monthly product summary retrieved successfully',
+            },
+            data: {
+              type: 'object',
+              properties: {
+                year: {
+                  type: 'integer',
+                  example: 2024,
+                },
+                monthlyProducts: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      month: {
+                        type: 'string',
+                        example: 'January',
+                      },
+                      total: {
+                        type: 'integer',
+                        example: 12,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
         UserResponse: {
           type: 'object',
           properties: {

--- a/src/routes/manager.routes.js
+++ b/src/routes/manager.routes.js
@@ -9,6 +9,7 @@ const {
   getSupervisors,
   getSalesUsers,
   getProducts,
+  getMonthlyProductSummary,
   handleValidationErrors,
 } = require('../controllers/manager.controller');
 
@@ -129,6 +130,32 @@ router.get('/supervisors', getSupervisors);
  *               $ref: '#/components/schemas/PaginatedUsersResponse'
  */
 router.get('/sales', getSalesUsers);
+
+/**
+ * @swagger
+ * /api/managers/products/monthly-summary:
+ *   get:
+ *     summary: Get monthly product summary for a year
+ *     tags: [Manager]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: year
+ *         schema:
+ *           type: integer
+ *           minimum: 1900
+ *           maximum: 9999
+ *         description: Year to summarise. Defaults to the current year when omitted.
+ *     responses:
+ *       200:
+ *         description: Monthly product summary retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MonthlyProductSummaryResponse'
+ */
+router.get('/products/monthly-summary', getMonthlyProductSummary);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- add a manager service method that aggregates active products per month for a given year
- expose the monthly summary via a validated controller endpoint and protected manager route
- document the new API and response schema in Swagger

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68cc13f9454c8326b3a95a81866eb9b4