### PR TITLE
Fix monthly product summary date column reference

### DIFF
--- a/src/services/manager.service.js
+++ b/src/services/manager.service.js
@@ -166,7 +166,14 @@ class ManagerService {
 
       const startOfYear = new Date(Date.UTC(year, 0, 1));
       const startOfNextYear = new Date(Date.UTC(year + 1, 0, 1));
-      const monthExpression = sequelize.fn('DATE_TRUNC', 'month', sequelize.col('purchasedAt'));
+
+      const productTableNameData = Product.getTableName();
+      const productTableName = typeof productTableNameData === 'string'
+        ? productTableNameData
+        : productTableNameData.tableName;
+      const purchasedAtField = Product.rawAttributes.purchasedAt.field || 'purchasedAt';
+      const purchasedAtColumn = sequelize.col(`${productTableName}.${purchasedAtField}`);
+      const monthExpression = sequelize.fn('DATE_TRUNC', 'month', purchasedAtColumn);
 
       const results = await Product.findAll({
         attributes: [


### PR DESCRIPTION
## Summary
- update the monthly summary date truncation to reference the products.purchased_at column exposed by Sequelize metadata
- reuse the computed month expression in the select, group, and order clauses so every part of the query targets the same column

## Testing
- npm install *(fails: 403 Forbidden while downloading doctrine-2.1.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb5df82088326ae66e3f2694f5d7d