### PR TITLE
Use model alias for monthly product summary grouping

### DIFF
--- a/src/services/manager.service.js
+++ b/src/services/manager.service.js
@@ -167,12 +167,8 @@ class ManagerService {
       const startOfYear = new Date(Date.UTC(year, 0, 1));
       const startOfNextYear = new Date(Date.UTC(year + 1, 0, 1));
 
-      const productTableNameData = Product.getTableName();
-      const productTableName = typeof productTableNameData === 'string'
-        ? productTableNameData
-        : productTableNameData.tableName;
       const purchasedAtField = Product.rawAttributes.purchasedAt.field || 'purchasedAt';
-      const purchasedAtColumn = sequelize.col(`${productTableName}.${purchasedAtField}`);
+      const purchasedAtColumn = sequelize.col(`${Product.name}.${purchasedAtField}`);
       const monthExpression = sequelize.fn('DATE_TRUNC', 'month', purchasedAtColumn);
 
       const results = await Product.findAll({


### PR DESCRIPTION
## Summary
- switch the monthly summary query to reference the Product model alias when building the purchasedAt column expression to avoid table-name specific SQL

## Testing
- npm install --registry=https://registry.npmmirror.com *(fails: 403 Forbidden downloading doctrine-2.1.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb9ced91883269a6dd9e670fe6306