### PR TITLE
Use MySQL compatible month aggregation

### DIFF
--- a/src/services/manager.service.js
+++ b/src/services/manager.service.js
@@ -169,7 +169,11 @@ class ManagerService {
 
       const createdAt = Product.rawAttributes.createdAt.field || 'createdAt';
       const createdAtColumn = sequelize.col(`${Product.name}.${createdAt}`);
-      const monthExpression = sequelize.fn('DATE_TRUNC', 'month', createdAtColumn);
+      const monthExpression = sequelize.fn(
+        'DATE_FORMAT',
+        createdAtColumn,
+        '%Y-%m-01T00:00:00.000Z',
+      );
 
       const results = await Product.findAll({
         attributes: [


### PR DESCRIPTION
## Summary
- replace the DATE_TRUNC usage in the manager monthly summary with DATE_FORMAT so the query runs on MySQL
- keep the grouped month value parseable as the UTC start of the month for client consumption

## Testing
- npm run lint *(fails: ESLint 9 requires a flat config and the repo still has a legacy configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc9cd5ce48326a803303a1a7aa8bb