### PR TITLE
Fix createdAt filters for product queries

### DIFF
--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -25,13 +25,13 @@ const buildProductFilters = (query, user, sequelize) => {
   // Date range filters
   if (query.created_at_from || query.created_at_to) {
     const dateFilter = {};
-    if (query.created_at) {
+    if (query.created_at_from) {
       dateFilter[Op.gte] = query.created_at_from;
     }
     if (query.created_at_to) {
       dateFilter[Op.lte] = query.created_at_to;
     }
-    where.created_At = dateFilter;
+    where.createdAt = dateFilter;
   }
   
   // Creator filter


### PR DESCRIPTION
## Summary
- update product filter builder to map created_at_from/to to createdAt with the correct operators

## Testing
- npm install *(fails: 403 Forbidden - https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68d14c5312608326a21b548e2be54897