### PR TITLE
Add supervisor filter to product queries

### DIFF
--- a/src/controllers/manager.controller.js
+++ b/src/controllers/manager.controller.js
@@ -176,6 +176,16 @@ const getProducts = async (req, res, next) => {
     const exporting = req.query.export === 'excel';
     const where = buildProductFilters(req.query, req.user);
 
+    const creatorInclude = {
+      model: User,
+      as: 'creator',
+      attributes: ['id', 'name', 'phone', 'supervisorId'],
+    };
+
+    if (req.query.supervisor_id) {
+      creatorInclude.where = { supervisorId: req.query.supervisor_id };
+    }
+
     const baseOptions = {
       where,
       include: [
@@ -184,11 +194,7 @@ const getProducts = async (req, res, next) => {
           as: 'store',
           attributes: ['id', 'name', 'address', 'phone'],
         },
-        {
-          model: User,
-          as: 'creator',
-          attributes: ['id', 'name', 'phone'],
-        },
+        creatorInclude,
       ],
       distinct: true,
     };

--- a/src/controllers/supervisor.controller.js
+++ b/src/controllers/supervisor.controller.js
@@ -67,6 +67,16 @@ const getProducts = async (req, res, next) => {
     const exporting = req.query.export === 'excel';
     const where = buildProductFilters(req.query, req.user);
 
+    const creatorInclude = {
+      model: User,
+      as: 'creator',
+      attributes: ['id', 'name', 'phone', 'supervisorId'],
+    };
+
+    if (req.query.supervisor_id) {
+      creatorInclude.where = { supervisorId: req.query.supervisor_id };
+    }
+
     const baseOptions = {
       where,
       include: [
@@ -75,11 +85,7 @@ const getProducts = async (req, res, next) => {
           as: 'store',
           attributes: ['id', 'name', 'address', 'phone'],
         },
-        {
-          model: User,
-          as: 'creator',
-          attributes: ['id', 'name', 'phone'],
-        },
+        creatorInclude,
       ],
       distinct: true,
     };

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -38,7 +38,11 @@ const buildProductFilters = (query, user, sequelize) => {
   if (query.creator_id) {
     where.creatorId = query.creator_id;
   }
-  
+
+  if (query.supervisor_id) {
+    where['$creator.supervisorId$'] = query.supervisor_id;
+  }
+
   // Mine filter (only for SALES role)
   if (query.mine === 'true' && user.role === 'SALES') {
     where.creatorId = user.sub;


### PR DESCRIPTION
## Summary
- allow manager and supervisor product listings to accept a supervisor_id filter
- include creator.supervisorId on product queries so joined filtering works for exports
- extend product filter builder to constrain results by the creator's supervisor when requested

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68d14c5705608326afa9912baa49cd84