### PR TITLE
Fix Swagger created_at parameter reference and add export URL example

### DIFF
--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -94,7 +94,7 @@ const options = {
           },
           description: 'Filter by store ID',
         },
-        CretatedAtFromParam: {
+        CreatedAtFromParam: {
           in: 'query',
           name: 'created_at_from',
           schema: {
@@ -137,7 +137,9 @@ const options = {
             type: 'string',
             enum: ['excel'],
           },
-          description: 'Export format (returns .xlsx file instead of JSON)',
+          description:
+            'Export format (returns .xlsx file instead of JSON). Example request: GET /api/sales/products?export=excel&created_at_from=2024-01-01&created_at_to=2024-01-31',
+          example: 'excel',
         },
       },
       schemas: {


### PR DESCRIPTION
## Summary
- correct the Swagger component name to `CreatedAtFromParam` so existing references resolve
- expand the export parameter description with a full Excel export URL example and surface the default value via the `example` field

## Testing
- npm install *(fails: registry returned 403 for doctrine-2.1.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68d14c5eeb508326ad14d8e2a163637c