### PR TITLE
Add authenticated password update endpoint

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -31,10 +31,24 @@ const loginValidation = [
     .withMessage('Password must be at least 6 characters'),
 ];
 
+const updatePasswordValidation = [
+  body('newPassword')
+    .notEmpty()
+    .withMessage('New password is required')
+    .isLength({ min: 6 })
+    .withMessage('New password must be at least 6 characters'),
+  body('currentPassword')
+    .optional()
+    .isString()
+    .withMessage('Current password must be a string')
+    .isLength({ min: 6 })
+    .withMessage('Current password must be at least 6 characters'),
+];
+
 const login = async (req, res, next) => {
   try {
     const { phone, password } = req.body;
-    
+
     const result = await authService.login(phone, password);
     
     res.json(response.success('Login successful', result));
@@ -46,9 +60,28 @@ const login = async (req, res, next) => {
   }
 };
 
+const updatePassword = async (req, res, next) => {
+  try {
+    const { newPassword, currentPassword } = req.body;
+
+    req.currentUser.password = newPassword;
+
+    const updatedUser = await authService.updatePassword(req.currentUser, { currentPassword });
+
+    res.json(response.success('Password updated successfully', updatedUser));
+  } catch (error) {
+    if (error.statusCode) {
+      return res.status(error.statusCode).json(response.error(error.message));
+    }
+    next(error);
+  }
+};
+
 module.exports = {
   loginLimiter,
   loginValidation,
   login,
+  updatePasswordValidation,
+  updatePassword,
   handleValidationErrors,
 };

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -161,6 +161,23 @@ const options = {
             },
           },
         },
+        UpdatePasswordRequest: {
+          type: 'object',
+          required: ['newPassword'],
+          properties: {
+            currentPassword: {
+              type: 'string',
+              minLength: 6,
+              nullable: true,
+              example: 'oldPassword123',
+            },
+            newPassword: {
+              type: 'string',
+              minLength: 6,
+              example: 'newSecurePassword123',
+            },
+          },
+        },
         CreateSupervisorRequest: {
           type: 'object',
           required: ['phone', 'password', 'name'],
@@ -335,6 +352,22 @@ const options = {
                   $ref: '#/components/schemas/User',
                 },
               },
+            },
+          },
+        },
+        UpdatePasswordResponse: {
+          type: 'object',
+          properties: {
+            success: {
+              type: 'boolean',
+              example: true,
+            },
+            message: {
+              type: 'string',
+              example: 'Password updated successfully',
+            },
+            data: {
+              $ref: '#/components/schemas/User',
             },
           },
         },

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -3,8 +3,11 @@ const {
   loginLimiter,
   loginValidation,
   login,
+  updatePasswordValidation,
+  updatePassword,
   handleValidationErrors,
 } = require('../controllers/auth.controller');
+const { authenticate } = require('../middlewares/auth');
 
 const router = express.Router();
 
@@ -41,5 +44,47 @@ const router = express.Router();
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.post('/login', loginLimiter, loginValidation, handleValidationErrors, login);
+
+/**
+ * @swagger
+ * /api/auth/password:
+ *   put:
+ *     summary: Update current user's password
+ *     tags: [Authentication]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/UpdatePasswordRequest'
+ *     responses:
+ *       200:
+ *         description: Password updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UpdatePasswordResponse'
+ *       400:
+ *         description: Validation error or incorrect current password
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.put(
+  '/password',
+  authenticate,
+  updatePasswordValidation,
+  handleValidationErrors,
+  updatePassword,
+);
 
 module.exports = router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -49,6 +49,40 @@ class AuthService {
       throw error;
     }
   }
+
+  async updatePassword(user, { currentPassword } = {}) {
+    try {
+      if (currentPassword) {
+        const userWithPassword = await User.scope('withPassword').findByPk(user.id);
+
+        if (!userWithPassword) {
+          const notFoundError = new Error('User not found');
+          notFoundError.statusCode = 404;
+          throw notFoundError;
+        }
+
+        const isValid = await userWithPassword.comparePassword(currentPassword);
+
+        if (!isValid) {
+          const invalidPasswordError = new Error('Current password is incorrect');
+          invalidPasswordError.statusCode = 400;
+          throw invalidPasswordError;
+        }
+      }
+
+      await user.save();
+
+      logger.info(`User ${user.id} updated password successfully`);
+
+      return user.toSafeJSON();
+    } catch (error) {
+      logger.error('Password update failed:', {
+        userId: user.id,
+        error: error.message,
+      });
+      throw error;
+    }
+  }
 }
 
 module.exports = new AuthService();


### PR DESCRIPTION
## Summary
- add validation and controller logic to support password updates for the authenticated user
- extend the auth service with a helper that verifies the optional current password and saves the hashed update
- expose a protected PUT /api/auth/password route and document the request/response in Swagger

## Testing
- npm run lint *(fails: ESLint requires local dependencies but npm install is blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d153dfc68c8326924f3e53dfdce634