### PR TITLE
feat: add password reset by phone endpoint

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -31,12 +31,25 @@ const loginValidation = [
     .withMessage('Password must be at least 6 characters'),
 ];
 
+const forgotPasswordValidation = [
+  body('phone')
+    .notEmpty()
+    .withMessage('Phone number is required')
+    .isLength({ min: 10, max: 20 })
+    .withMessage('Phone number must be between 10 and 20 characters'),
+  body('newPassword')
+    .notEmpty()
+    .withMessage('New password is required')
+    .isLength({ min: 6 })
+    .withMessage('New password must be at least 6 characters'),
+];
+
 const login = async (req, res, next) => {
   try {
     const { phone, password } = req.body;
-    
+
     const result = await authService.login(phone, password);
-    
+
     res.json(response.success('Login successful', result));
   } catch (error) {
     if (error.message === 'Invalid credentials') {
@@ -46,9 +59,29 @@ const login = async (req, res, next) => {
   }
 };
 
+const forgotPassword = async (req, res, next) => {
+  try {
+    const { phone, newPassword } = req.body;
+
+    const user = await authService.resetPassword(phone, newPassword);
+
+    if (!user) {
+      return res
+        .status(404)
+        .json(response.error('Active user with the provided phone number was not found'));
+    }
+
+    return res.json(response.success('Password updated successfully', user));
+  } catch (error) {
+    next(error);
+  }
+};
+
 module.exports = {
   loginLimiter,
   loginValidation,
   login,
+  forgotPasswordValidation,
+  forgotPassword,
   handleValidationErrors,
 };

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -161,6 +161,23 @@ const options = {
             },
           },
         },
+        ForgotPasswordRequest: {
+          type: 'object',
+          required: ['phone', 'newPassword'],
+          properties: {
+            phone: {
+              type: 'string',
+              minLength: 10,
+              maxLength: 20,
+              example: '08114328888',
+            },
+            newPassword: {
+              type: 'string',
+              minLength: 6,
+              example: 'newStrongPassword123',
+            },
+          },
+        },
         CreateSupervisorRequest: {
           type: 'object',
           required: ['phone', 'password', 'name'],

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -3,6 +3,8 @@ const {
   loginLimiter,
   loginValidation,
   login,
+  forgotPasswordValidation,
+  forgotPassword,
   handleValidationErrors,
 } = require('../controllers/auth.controller');
 
@@ -41,5 +43,45 @@ const router = express.Router();
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.post('/login', loginLimiter, loginValidation, handleValidationErrors, login);
+
+/**
+ * @swagger
+ * /api/auth/password/forgot:
+ *   post:
+ *     summary: Reset password by phone
+ *     description: Allows an active user to reset their password using their phone number.
+ *     tags: [Authentication]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ForgotPasswordRequest'
+ *     responses:
+ *       200:
+ *         description: Password updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SuccessResponse'
+ *       404:
+ *         description: User with the provided phone number was not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.post(
+  '/password/forgot',
+  forgotPasswordValidation,
+  handleValidationErrors,
+  forgotPassword
+);
 
 module.exports = router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -49,6 +49,33 @@ class AuthService {
       throw error;
     }
   }
+
+  async resetPassword(phone, newPassword) {
+    try {
+      const user = await User.scope('withPassword').findOne({
+        where: { phone, isActive: true },
+      });
+
+      if (!user) {
+        return null;
+      }
+
+      user.password = newPassword;
+      await user.save();
+
+      logger.info(`Password reset for user ${user.phone}`, {
+        userId: user.id,
+      });
+
+      return user.toSafeJSON();
+    } catch (error) {
+      logger.error('Password reset failed:', {
+        phone,
+        error: error.message,
+      });
+      throw error;
+    }
+  }
 }
 
 module.exports = new AuthService();


### PR DESCRIPTION
## Summary
- add validation and controller handler to reset an active user's password using their phone number
- implement an auth service helper that reuses the model hooks while updating the password
- expose POST /api/auth/password/forgot without authentication and document the workflow in Swagger

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68d154278ee88326a1d3466a0516c6b8