### PR TITLE
Add product update endpoint for sales users

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db:migrate:undo": "npx sequelize-cli db:migrate:undo",
     "db:seed": "npx sequelize-cli db:seed:all",
     "db:seed:undo": "npx sequelize-cli db:seed:undo:all",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -304,6 +304,42 @@ const options = {
             },
           },
         },
+        UpdateProductRequest: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              minLength: 2,
+              maxLength: 200,
+              example: 'iPhone 15 Pro Max',
+            },
+            code: {
+              type: 'string',
+              minLength: 2,
+              maxLength: 50,
+              example: 'APPLE-IP15PM-001-UPDATED',
+            },
+            price: {
+              type: 'number',
+              format: 'float',
+              minimum: 0,
+              example: 20990000,
+            },
+            notes: {
+              type: 'string',
+              maxLength: 1000,
+              example: 'Updated promo price available this month only.',
+            },
+            persen: {
+              type: 'integer',
+              example: 25,
+            },
+            isActive: {
+              type: 'boolean',
+              example: true,
+            },
+          },
+        },
 
         // Response Schemas
         SuccessResponse: {

--- a/src/routes/sales.routes.js
+++ b/src/routes/sales.routes.js
@@ -4,6 +4,8 @@ const { requireSales } = require('../middlewares/role');
 const {
   createProductValidation,
   createProduct,
+  updateProductValidation,
+  updateProduct,
   deleteProduct,
   getProducts,
   handleValidationErrors,
@@ -37,6 +39,43 @@ router.use(authenticate, requireSales);
  *               $ref: '#/components/schemas/ProductResponse'
  */
 router.post('/products', createProductValidation, handleValidationErrors, createProduct);
+
+/**
+ * @swagger
+ * /api/sales/products/{id}:
+ *   put:
+ *     summary: Update a product (only own products)
+ *     tags: [Sales]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/UpdateProductRequest'
+ *     responses:
+ *       200:
+ *         description: Product updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ProductResponse'
+ *       404:
+ *         description: Product not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.put('/products/:id', updateProductValidation, handleValidationErrors, updateProduct);
 
 /**
  * @swagger

--- a/tests/helpers/mock-modules.js
+++ b/tests/helpers/mock-modules.js
@@ -1,0 +1,27 @@
+const Module = require('node:module');
+const path = require('node:path');
+
+const stubMap = {
+  'express-validator': path.resolve(__dirname, '../stubs/express-validator.js'),
+  jsonwebtoken: path.resolve(__dirname, '../stubs/jsonwebtoken.js'),
+  dotenv: path.resolve(__dirname, '../stubs/dotenv.js'),
+  sequelize: path.resolve(__dirname, '../stubs/sequelize.js'),
+};
+
+module.exports = () => {
+  const originalResolveFilename = Module._resolveFilename;
+
+  Module._resolveFilename = function mockResolve(request, parent, isMain, options) {
+    if (stubMap[request]) {
+      return stubMap[request];
+    }
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  };
+
+  return () => {
+    Module._resolveFilename = originalResolveFilename;
+    Object.values(stubMap).forEach((stubPath) => {
+      delete require.cache[stubPath];
+    });
+  };
+};

--- a/tests/sales-update.controller.test.js
+++ b/tests/sales-update.controller.test.js
@@ -1,0 +1,244 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const setupModuleMocks = require('./helpers/mock-modules');
+
+const restoreModuleMocks = setupModuleMocks();
+
+const { validationResult } = require('express-validator');
+
+test.after(() => {
+  restoreModuleMocks();
+});
+
+const controllerPath = path.resolve(__dirname, '../src/controllers/sales.controller.js');
+const servicePath = path.resolve(__dirname, '../src/services/sales.service.js');
+const modelsPath = path.resolve(__dirname, '../src/models/index.js');
+const loggerPath = path.resolve(__dirname, '../src/utils/logger.js');
+const excelPath = path.resolve(__dirname, '../src/utils/excel.js');
+
+const loadController = (serviceMock) => {
+  delete require.cache[controllerPath];
+  delete require.cache[servicePath];
+  delete require.cache[modelsPath];
+  delete require.cache[loggerPath];
+  delete require.cache[excelPath];
+
+  const baseMock = {
+    createProduct: async () => undefined,
+    deleteProduct: async () => undefined,
+    updateProduct: async () => undefined,
+  };
+
+  require.cache[modelsPath] = {
+    id: modelsPath,
+    filename: modelsPath,
+    loaded: true,
+    exports: {
+      Product: {},
+      Store: {},
+      User: {},
+    },
+  };
+
+  require.cache[loggerPath] = {
+    id: loggerPath,
+    filename: loggerPath,
+    loaded: true,
+    exports: {
+      info: () => {},
+      error: () => {},
+    },
+  };
+
+  require.cache[excelPath] = {
+    id: excelPath,
+    filename: excelPath,
+    loaded: true,
+    exports: {
+      streamProductsXlsx: async () => {},
+    },
+  };
+
+  require.cache[servicePath] = {
+    id: servicePath,
+    filename: servicePath,
+    loaded: true,
+    exports: { ...baseMock, ...serviceMock },
+  };
+
+  const controller = require(controllerPath);
+
+  const cleanup = () => {
+    delete require.cache[controllerPath];
+    delete require.cache[servicePath];
+    delete require.cache[modelsPath];
+    delete require.cache[loggerPath];
+    delete require.cache[excelPath];
+  };
+
+  return { controller, cleanup };
+};
+
+const runValidations = async (validations, req) => {
+  for (const validation of validations) {
+    // eslint-disable-next-line no-await-in-loop
+    await validation.run(req);
+  }
+  return validationResult(req);
+};
+
+test('updateProduct controller returns success response with updated product', async () => {
+  const updatedProduct = { id: 'product-123', name: 'Updated Name' };
+  const { controller, cleanup } = loadController({
+    updateProduct: async () => updatedProduct,
+  });
+
+  try {
+    const req = {
+      params: { id: 'product-123' },
+      body: { name: 'Updated Name' },
+      user: { sub: 'sales-1' },
+    };
+
+    let statusCode;
+    let jsonPayload;
+    const res = {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    let nextCalled = false;
+    const next = () => {
+      nextCalled = true;
+    };
+
+    await controller.updateProduct(req, res, next);
+
+    assert.equal(statusCode, undefined);
+    assert.ok(jsonPayload.success);
+    assert.equal(jsonPayload.message, 'Product updated successfully');
+    assert.equal(jsonPayload.data, updatedProduct);
+    assert.equal(nextCalled, false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('updateProduct controller converts missing product to 404 error', async () => {
+  const { controller, cleanup } = loadController({
+    updateProduct: async () => {
+      const error = new Error('Product not found');
+      throw error;
+    },
+  });
+
+  try {
+    const req = {
+      params: { id: 'product-unknown' },
+      body: { name: 'Does not matter' },
+      user: { sub: 'sales-1' },
+    };
+
+    let statusCode;
+    let jsonPayload;
+    const res = {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    let nextCalled = false;
+    const next = () => {
+      nextCalled = true;
+    };
+
+    await controller.updateProduct(req, res, next);
+
+    assert.equal(statusCode, 404);
+    assert.ok(!jsonPayload.success);
+    assert.equal(jsonPayload.message, 'Product not found');
+    assert.equal(nextCalled, false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('updateProductValidation flags missing fields and invalid id', async () => {
+  const { controller, cleanup } = loadController({});
+
+  try {
+    const req = {
+      params: { id: 'not-a-uuid' },
+      body: {},
+    };
+
+    const result = await runValidations(controller.updateProductValidation, req);
+
+    assert.equal(result.isEmpty(), false);
+    const messages = result.array().map((error) => error.msg);
+    assert.ok(messages.includes('Product id must be a valid UUID'));
+    assert.ok(messages.includes('At least one field must be provided for update'));
+  } finally {
+    cleanup();
+  }
+});
+
+test('authenticate middleware rejects missing authorization header', async () => {
+  const authPath = path.resolve(__dirname, '../src/middlewares/auth.js');
+
+  delete require.cache[modelsPath];
+  require.cache[modelsPath] = {
+    id: modelsPath,
+    filename: modelsPath,
+    loaded: true,
+    exports: {
+      User: { findByPk: async () => null },
+    },
+  };
+
+  delete require.cache[authPath];
+  const { authenticate } = require(authPath);
+
+  const req = { headers: {} };
+  let statusCode;
+  let payload;
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(body) {
+      payload = body;
+      return this;
+    },
+  };
+
+  let nextCalled = false;
+  const next = () => {
+    nextCalled = true;
+  };
+
+  try {
+    await authenticate(req, res, next);
+
+    assert.equal(statusCode, 401);
+    assert.ok(!payload.success);
+    assert.equal(payload.message, 'Access token required');
+    assert.equal(nextCalled, false);
+  } finally {
+    delete require.cache[authPath];
+    delete require.cache[modelsPath];
+  }
+});

--- a/tests/sales-update.service.test.js
+++ b/tests/sales-update.service.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const setupModuleMocks = require('./helpers/mock-modules');
+
+const restoreModuleMocks = setupModuleMocks();
+
+test.after(() => {
+  restoreModuleMocks();
+});
+
+const servicePath = path.resolve(__dirname, '../src/services/sales.service.js');
+const modelsPath = path.resolve(__dirname, '../src/models/index.js');
+const loggerPath = path.resolve(__dirname, '../src/utils/logger.js');
+
+const withServiceMocks = (productFindOne) => {
+  delete require.cache[servicePath];
+  delete require.cache[modelsPath];
+  delete require.cache[loggerPath];
+
+  const infoLogs = [];
+  const errorLogs = [];
+
+  require.cache[modelsPath] = {
+    id: modelsPath,
+    filename: modelsPath,
+    loaded: true,
+    exports: {
+      Product: {
+        findOne: productFindOne,
+      },
+      Store: {},
+      User: {},
+    },
+  };
+
+  require.cache[loggerPath] = {
+    id: loggerPath,
+    filename: loggerPath,
+    loaded: true,
+    exports: {
+      info: (...args) => infoLogs.push(args),
+      error: (...args) => errorLogs.push(args),
+    },
+  };
+
+  const salesService = require(servicePath);
+
+  const cleanup = () => {
+    delete require.cache[servicePath];
+    delete require.cache[modelsPath];
+    delete require.cache[loggerPath];
+  };
+
+  return { salesService, infoLogs, errorLogs, cleanup };
+};
+
+test('updateProduct applies allowed updates and logs the action', async () => {
+  const saved = { value: false };
+  const productRecord = {
+    id: 'product-123',
+    creatorId: 'sales-1',
+    code: 'P-001',
+    name: 'Old Name',
+    price: 100,
+    notes: 'Initial note',
+    save: async () => {
+      saved.value = true;
+    },
+  };
+
+  const { salesService, infoLogs, errorLogs, cleanup } = withServiceMocks(async () => productRecord);
+
+  try {
+    const result = await salesService.updateProduct('product-123', 'sales-1', {
+      name: 'Updated Name',
+      price: 150,
+      notes: 'Updated note',
+      unknownField: 'ignored',
+    });
+
+    assert.equal(result, productRecord);
+    assert.equal(productRecord.name, 'Updated Name');
+    assert.equal(productRecord.price, 150);
+    assert.equal(productRecord.notes, 'Updated note');
+    assert.equal(productRecord.unknownField, undefined);
+    assert.ok(saved.value, 'product.save should be called');
+    assert.equal(errorLogs.length, 0);
+    assert.ok(infoLogs.length > 0);
+    assert.equal(infoLogs[0][0], 'Product updated by sales user:');
+  } finally {
+    cleanup();
+  }
+});
+
+test('updateProduct throws when product is not found and logs the error', async () => {
+  const { salesService, errorLogs, cleanup } = withServiceMocks(async () => null);
+
+  try {
+    await assert.rejects(
+      salesService.updateProduct('missing', 'sales-1', { name: 'Nope' }),
+      /Product not found/,
+    );
+    assert.ok(errorLogs.length > 0);
+    assert.equal(errorLogs[0][0], 'Failed to update product:');
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/stubs/dotenv.js
+++ b/tests/stubs/dotenv.js
@@ -1,0 +1,3 @@
+module.exports = {
+  config: () => ({ parsed: {} }),
+};

--- a/tests/stubs/express-validator.js
+++ b/tests/stubs/express-validator.js
@@ -1,0 +1,285 @@
+const isEmptyValue = (value) => value === undefined || value === null || value === '';
+
+const ensureErrorStore = (req) => {
+  if (!req._validationErrors) {
+    Object.defineProperty(req, '_validationErrors', {
+      value: [],
+      writable: true,
+      enumerable: false,
+    });
+  }
+  return req._validationErrors;
+};
+
+const addError = (req, field, location, message) => {
+  const errors = ensureErrorStore(req);
+  errors.push({
+    msg: message,
+    param: field || '_error',
+    location,
+  });
+};
+
+const getLocationContainer = (req, location) => {
+  if (location === 'body') {
+    if (!req.body) req.body = {};
+    return req.body;
+  }
+  if (location === 'params') {
+    if (!req.params) req.params = {};
+    return req.params;
+  }
+  if (location === 'query') {
+    if (!req.query) req.query = {};
+    return req.query;
+  }
+  return {};
+};
+
+const addValidator = (chain, runFn, defaultMessage, options = {}) => {
+  chain._validators.push({
+    run: runFn,
+    defaultMessage,
+    customMessage: null,
+    isSanitizer: false,
+    useErrorMessage: options.useErrorMessage || false,
+  });
+};
+
+const addSanitizer = (chain, runFn) => {
+  chain._validators.push({
+    run: runFn,
+    isSanitizer: true,
+  });
+};
+
+const createChain = (field, location) => {
+  const chain = {
+    _field: field,
+    _location: location,
+    _validators: [],
+    _optional: false,
+    _optionalOptions: {},
+    optional(options = {}) {
+      this._optional = true;
+      this._optionalOptions = options;
+      return this;
+    },
+    notEmpty() {
+      addValidator(this, (value) => {
+        if (isEmptyValue(value)) {
+          throw new Error('Value cannot be empty');
+        }
+        if (typeof value === 'string' && value.trim() === '') {
+          throw new Error('Value cannot be empty');
+        }
+      }, 'Value cannot be empty');
+      return this;
+    },
+    isLength({ min, max }) {
+      addValidator(this, (value) => {
+        const str = value === undefined || value === null ? '' : String(value);
+        if (typeof min === 'number' && str.length < min) {
+          throw new Error('Value is shorter than minimum length');
+        }
+        if (typeof max === 'number' && str.length > max) {
+          throw new Error('Value is longer than maximum length');
+        }
+      }, 'Invalid length');
+      return this;
+    },
+    isFloat(options = {}) {
+      addValidator(this, (value) => {
+        if (isEmptyValue(value)) {
+          throw new Error('Value must be a number');
+        }
+        const num = Number(value);
+        if (Number.isNaN(num)) {
+          throw new Error('Value must be a number');
+        }
+        if (typeof options.min === 'number' && num < options.min) {
+          throw new Error('Value is less than minimum');
+        }
+      }, 'Invalid number');
+      return this;
+    },
+    toFloat() {
+      addSanitizer(this, (value) => {
+        if (isEmptyValue(value)) {
+          return value;
+        }
+        const num = Number(value);
+        return Number.isNaN(num) ? value : num;
+      });
+      return this;
+    },
+    isInt(options = {}) {
+      addValidator(this, (value) => {
+        if (isEmptyValue(value)) {
+          throw new Error('Value must be an integer');
+        }
+        const num = typeof value === 'number' ? value : Number(value);
+        if (!Number.isInteger(num)) {
+          throw new Error('Value must be an integer');
+        }
+        if (typeof options.min === 'number' && num < options.min) {
+          throw new Error('Value is less than minimum');
+        }
+      }, 'Invalid integer');
+      return this;
+    },
+    isBoolean() {
+      addValidator(this, (value) => {
+        if (isEmptyValue(value)) {
+          throw new Error('Value must be a boolean');
+        }
+        if (typeof value === 'boolean') {
+          return;
+        }
+        if (typeof value === 'string') {
+          const normalized = value.toLowerCase();
+          if (normalized === 'true' || normalized === 'false') {
+            return;
+          }
+        }
+        throw new Error('Value must be a boolean');
+      }, 'Invalid boolean');
+      return this;
+    },
+    toBoolean() {
+      addSanitizer(this, (value) => {
+        if (typeof value === 'boolean') {
+          return value;
+        }
+        if (typeof value === 'string') {
+          const normalized = value.toLowerCase();
+          if (normalized === 'true') {
+            return true;
+          }
+          if (normalized === 'false') {
+            return false;
+          }
+        }
+        return Boolean(value);
+      });
+      return this;
+    },
+    isString() {
+      addValidator(this, (value) => {
+        if (typeof value !== 'string') {
+          throw new Error('Value must be a string');
+        }
+      }, 'Invalid string');
+      return this;
+    },
+    isUUID() {
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      addValidator(this, (value) => {
+        if (typeof value !== 'string' || !uuidRegex.test(value)) {
+          throw new Error('Value must be a valid UUID');
+        }
+      }, 'Invalid UUID');
+      return this;
+    },
+    custom(fn) {
+      addValidator(
+        this,
+        async (value, context) => {
+          const result = fn(value, context);
+          if (result instanceof Promise) {
+            await result;
+          } else if (result === false) {
+            throw new Error('Invalid value');
+          }
+        },
+        'Invalid value',
+        { useErrorMessage: true },
+      );
+      return this;
+    },
+    withMessage(message) {
+      if (this._validators.length > 0) {
+        const last = this._validators[this._validators.length - 1];
+        last.customMessage = message;
+      }
+      return this;
+    },
+    async run(req) {
+      const data = getLocationContainer(req, this._location);
+      const targetField = this._field;
+      const valueExists = targetField === undefined
+        || Object.prototype.hasOwnProperty.call(data, targetField);
+      const rawValue = targetField === undefined ? data : data[targetField];
+      const skipForOptional = () => {
+        if (!this._optional) {
+          return false;
+        }
+        if (!valueExists) {
+          return true;
+        }
+        if (isEmptyValue(rawValue)) {
+          return true;
+        }
+        if (this._optionalOptions.checkFalsy && !rawValue) {
+          return true;
+        }
+        if (this._optionalOptions.nullable && rawValue === null) {
+          return true;
+        }
+        return false;
+      };
+
+      if (skipForOptional()) {
+        return;
+      }
+
+      let value = rawValue;
+
+      for (const validator of this._validators) {
+        if (validator.isSanitizer) {
+          value = validator.run(value, { req });
+          if (targetField !== undefined) {
+            data[targetField] = value;
+          }
+          continue;
+        }
+
+        try {
+          const result = validator.run(value, { req });
+          if (result instanceof Promise) {
+            await result;
+          }
+        } catch (error) {
+          const message = validator.customMessage
+            || (validator.useErrorMessage && error && error.message)
+            || validator.defaultMessage;
+          addError(req, targetField, this._location, message);
+          return;
+        }
+      }
+
+      if (targetField !== undefined) {
+        data[targetField] = value;
+      }
+    },
+  };
+
+  return chain;
+};
+
+const body = (field) => createChain(field, 'body');
+const param = (field) => createChain(field, 'params');
+
+const validationResult = (req) => {
+  const errors = req._validationErrors || [];
+  return {
+    isEmpty: () => errors.length === 0,
+    array: () => errors.slice(),
+  };
+};
+
+module.exports = {
+  body,
+  param,
+  validationResult,
+};

--- a/tests/stubs/jsonwebtoken.js
+++ b/tests/stubs/jsonwebtoken.js
@@ -1,0 +1,16 @@
+const sign = (payload) => JSON.stringify(payload);
+
+const verify = (token) => {
+  try {
+    return JSON.parse(token);
+  } catch (error) {
+    const err = new Error('Invalid token');
+    err.name = 'JsonWebTokenError';
+    throw err;
+  }
+};
+
+module.exports = {
+  sign,
+  verify,
+};

--- a/tests/stubs/sequelize.js
+++ b/tests/stubs/sequelize.js
@@ -1,0 +1,23 @@
+const Op = {
+  or: Symbol('or'),
+  iLike: Symbol('iLike'),
+  gte: Symbol('gte'),
+  lte: Symbol('lte'),
+};
+
+class SequelizeStub {
+  constructor() {}
+
+  define() {
+    return {};
+  }
+}
+
+const DataTypes = new Proxy({}, {
+  get: () => ({}),
+});
+
+module.exports = SequelizeStub;
+module.exports.Sequelize = SequelizeStub;
+module.exports.Op = Op;
+module.exports.DataTypes = DataTypes;


### PR DESCRIPTION
## Summary
- add a sales service helper to update products owned by the authenticated sales user and log the change
- expose a PUT /api/sales/products/{id} endpoint with validation and swagger documentation
- cover the update flow with node:test suites for success, validation, and unauthorized access scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d175f9b8b08326bf773e42897c2a71