### PR TITLE
Add price warranty calculations for products

### DIFF
--- a/src/controllers/manager.controller.js
+++ b/src/controllers/manager.controller.js
@@ -6,6 +6,7 @@ const { handleValidationErrors } = require('../middlewares/validate');
 const { parsePaginationQuery, applyPaginationToFindOptions, buildPaginatedResponse } = require('../utils/pagination');
 const { buildProductFilters } = require('../utils/filters');
 const { streamProductsXlsx } = require('../utils/excel');
+const { formatProductForOutput } = require('../utils/product-pricing');
 const { Product, Store, User } = require('../models');
 
 const getDashboard = async (req, res, next) => {
@@ -204,15 +205,21 @@ const getProducts = async (req, res, next) => {
         ...baseOptions,
         order: [['createdAt', 'DESC']],
       });
-      return streamProductsXlsx(res, products, `products_manager_${Date.now()}.xlsx`);
+      const formattedProducts = products.map(formatProductForOutput);
+      return streamProductsXlsx(res, formattedProducts, `products_manager_${Date.now()}.xlsx`);
     }
 
     const pageInfo = parsePaginationQuery(req.query);
     const result = await Product.findAndCountAll(
       applyPaginationToFindOptions(baseOptions, pageInfo),
     );
-    
-    const paginatedResponse = buildPaginatedResponse(result, pageInfo);
+
+    const formattedResult = {
+      count: result.count,
+      rows: result.rows.map(formatProductForOutput),
+    };
+
+    const paginatedResponse = buildPaginatedResponse(formattedResult, pageInfo);
     res.json(response.paginated('Products retrieved successfully', paginatedResponse));
   } catch (error) {
     next(error);

--- a/src/controllers/supervisor.controller.js
+++ b/src/controllers/supervisor.controller.js
@@ -5,6 +5,7 @@ const { handleValidationErrors } = require('../middlewares/validate');
 const { parsePaginationQuery, applyPaginationToFindOptions, buildPaginatedResponse } = require('../utils/pagination');
 const { buildProductFilters } = require('../utils/filters');
 const { streamProductsXlsx } = require('../utils/excel');
+const { formatProductForOutput } = require('../utils/product-pricing');
 const { Product, Store, User } = require('../models');
 
 const createSalesValidation = [
@@ -95,15 +96,21 @@ const getProducts = async (req, res, next) => {
         ...baseOptions,
         order: [['createdAt', 'DESC']],
       });
-      return streamProductsXlsx(res, products, `products_supervisor_${Date.now()}.xlsx`);
+      const formattedProducts = products.map(formatProductForOutput);
+      return streamProductsXlsx(res, formattedProducts, `products_supervisor_${Date.now()}.xlsx`);
     }
 
     const pageInfo = parsePaginationQuery(req.query);
     const result = await Product.findAndCountAll(
       applyPaginationToFindOptions(baseOptions, pageInfo),
     );
-    
-    const paginatedResponse = buildPaginatedResponse(result, pageInfo);
+
+    const formattedResult = {
+      count: result.count,
+      rows: result.rows.map(formatProductForOutput),
+    };
+
+    const paginatedResponse = buildPaginatedResponse(formattedResult, pageInfo);
     res.json(response.paginated('Products retrieved successfully', paginatedResponse));
   } catch (error) {
     next(error);

--- a/src/db/migrations/20250923070000-add-price-warranty-to-products.js
+++ b/src/db/migrations/20250923070000-add-price-warranty-to-products.js
@@ -1,0 +1,17 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('products', 'price_warranty', {
+      type: Sequelize.DECIMAL(10, 2),
+      allowNull: false,
+      defaultValue: 0,
+    });
+
+    await queryInterface.sequelize.query(
+      'UPDATE products SET price_warranty = COALESCE(price, 0) - (COALESCE(price, 0) * COALESCE(persen, 0) / 100.0);'
+    );
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('products', 'price_warranty');
+  },
+};

--- a/src/db/seeders/20250101000003-demo-products.js
+++ b/src/db/seeders/20250101000003-demo-products.js
@@ -1,3 +1,5 @@
+const { calculatePriceWarranty } = require('../../utils/product-pricing');
+
 module.exports = {
   up: async (queryInterface) => {
     const products = [
@@ -7,6 +9,7 @@ module.exports = {
         code: 'APPLE-IP15P-001',
         price: 19990000,
         persen: 60,
+        price_warranty: calculatePriceWarranty(19990000, 60),
         notes: 'Latest iPhone model with titanium design',
         store_id: '11111111-1111-1111-1111-111111111111',
         creator_id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
@@ -20,6 +23,7 @@ module.exports = {
         code: 'SAMSUNG-GS24-001',
         price: 15999000,
         persen: 60,
+        price_warranty: calculatePriceWarranty(15999000, 60),
         store_id: '11111111-1111-1111-1111-111111111111',
         creator_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
         is_active: true,
@@ -32,6 +36,7 @@ module.exports = {
         code: 'APPLE-MBA-M3-001',
         price: 24999000,
         persen: 60,
+        price_warranty: calculatePriceWarranty(24999000, 60),
         notes: '13-inch laptop with M3 chip',
         store_id: '22222222-2222-2222-2222-222222222222',
         creator_id: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
@@ -45,6 +50,7 @@ module.exports = {
         code: 'SONY-WH1000-001',
         price: 5499000,
         persen: 60,
+        price_warranty: calculatePriceWarranty(5499000, 60),
         notes: 'Noise canceling headphones',
         store_id: '11111111-1111-1111-1111-111111111111',
         creator_id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
@@ -58,6 +64,7 @@ module.exports = {
         code: 'APPLE-IPP-129-001',
         price: 18999000,
         persen: 60,
+        price_warranty: calculatePriceWarranty(18999000, 60),
         notes: 'Professional tablet with M2 chip',
         store_id: '22222222-2222-2222-2222-222222222222',
         creator_id: 'ffffffff-ffff-ffff-ffff-ffffffffffff',

--- a/src/models/product.js
+++ b/src/models/product.js
@@ -1,3 +1,5 @@
+const { calculatePriceWarranty } = require('../utils/product-pricing');
+
 module.exports = (sequelize, DataTypes) => {
   const Product = sequelize.define('Product', {
     id: {
@@ -31,6 +33,11 @@ module.exports = (sequelize, DataTypes) => {
       validate: {
         min: 0,
       },
+    },
+    priceWarranty: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: false,
+      defaultValue: 0,
     },
     storeId: {
       type: DataTypes.UUID,
@@ -78,6 +85,18 @@ module.exports = (sequelize, DataTypes) => {
       },
     ],
   });
+
+  const applyPriceWarranty = (productInstance) => {
+    if (!productInstance) {
+      return;
+    }
+
+    const computedValue = calculatePriceWarranty(productInstance.price, productInstance.persen);
+    productInstance.setDataValue('priceWarranty', computedValue);
+  };
+
+  Product.addHook('beforeValidate', applyPriceWarranty);
+  Product.addHook('beforeSave', applyPriceWarranty);
 
   Product.associate = (models) => {
     // Product belongs to Store

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -9,6 +9,7 @@ const streamProductsXlsx = async (res, products, filename = 'products.xlsx') => 
     { header: 'Nama', key: 'name', width: 30 },
     { header: 'Kode', key: 'code', width: 20 },
     { header: 'Harga', key: 'price', width: 18 },
+    { header: 'Harga Garansi', key: 'priceWarranty', width: 18 },
     { header: 'Status', key: 'status', width: 15 },
     { header: 'Toko', key: 'storeName', width: 25 },
     { header: 'No. HP Toko', key: 'storePhone', width: 15 },
@@ -31,6 +32,7 @@ const streamProductsXlsx = async (res, products, filename = 'products.xlsx') => 
       name: product.name,
       code: product.code,
       price: product.price !== undefined && product.price !== null ? Number(product.price) : '',
+      priceWarranty: product.priceWarranty !== undefined && product.priceWarranty !== null ? Number(product.priceWarranty) : '',
       status: deriveStatus(product.isActive, product.createdAt), // <-- status terhitung
       storeName: product.store?.name || '',
       storePhone: product.store?.phone || '',

--- a/src/utils/product-pricing.js
+++ b/src/utils/product-pricing.js
@@ -1,0 +1,62 @@
+const toNumberOrZero = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : 0;
+};
+
+const toNullableNumber = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+};
+
+const roundToTwoDecimals = (value) => {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+};
+
+const calculatePriceWarranty = (price, persen) => {
+  const normalizedPrice = toNumberOrZero(price);
+  const normalizedPersen = toNumberOrZero(persen);
+
+  const discount = normalizedPrice * (normalizedPersen / 100);
+  const warrantyPrice = normalizedPrice - discount;
+
+  return roundToTwoDecimals(warrantyPrice);
+};
+
+const toPlainProduct = (product) => {
+  if (!product) {
+    return product;
+  }
+
+  if (typeof product.get === 'function') {
+    return product.get({ plain: true });
+  }
+
+  return product;
+};
+
+const formatProductForOutput = (product) => {
+  const plainProduct = toPlainProduct(product);
+  if (!plainProduct) {
+    return plainProduct;
+  }
+
+  const price = toNullableNumber(plainProduct.price);
+  const persen = toNullableNumber(plainProduct.persen);
+  const priceWarranty = calculatePriceWarranty(price ?? 0, persen ?? 0);
+
+  return {
+    ...plainProduct,
+    price,
+    persen,
+    priceWarranty,
+  };
+};
+
+module.exports = {
+  calculatePriceWarranty,
+  formatProductForOutput,
+};


### PR DESCRIPTION
## Summary
- add a price_warranty column to products and ensure it is kept in sync via model hooks and services
- expose the computed warranty price in product listings and Excel exports
- seed demo data and utilities with the new warranty pricing logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3c6f809888326be006d48b11a7477