### PR TITLE
Disable soft deletes for core entities

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -11,7 +11,7 @@ module.exports = {
     logging: false,
     define: {
       timestamps: true,
-      paranoid: true,
+      paranoid: false,
       underscored: true,
     },
   },
@@ -25,7 +25,7 @@ module.exports = {
     logging: false,
     define: {
       timestamps: true,
-      paranoid: true,
+      paranoid: false,
       underscored: true,
     },
   },
@@ -45,7 +45,7 @@ module.exports = {
     },
     define: {
       timestamps: true,
-      paranoid: true,
+      paranoid: false,
       underscored: true,
     },
   },

--- a/src/models/product.js
+++ b/src/models/product.js
@@ -65,7 +65,6 @@ module.exports = (sequelize, DataTypes) => {
     },
   }, {
     tableName: 'products',
-    paranoid: true,
     indexes: [
       {
         fields: ['code'],

--- a/src/models/store.js
+++ b/src/models/store.js
@@ -36,7 +36,6 @@ module.exports = (sequelize, DataTypes) => {
     },
   }, {
     tableName: 'stores',
-    paranoid: true,
   });
 
   Store.associate = (models) => {

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -55,7 +55,6 @@ module.exports = (sequelize, DataTypes) => {
     },
   }, {
     tableName: 'users',
-    paranoid: true,
     hooks: {
       beforeCreate: async (user) => {
         if (user.password) {


### PR DESCRIPTION
## Summary
- disable Sequelize paranoid mode globally so deletions remove rows
- remove paranoid configuration from product, store, and user models

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d49e7a2a948326a16c7886dc9a8c9d