### PR TITLE
Include inactive products in monthly summary

### DIFF
--- a/src/services/manager.service.js
+++ b/src/services/manager.service.js
@@ -204,7 +204,6 @@ class ManagerService {
           [sequelize.fn('COUNT', sequelize.col('id')), 'productCount'],
         ],
         where: {
-          isActive: true,
           createdAt: {
             [Op.gte]: startOfYear,
             [Op.lt]: startOfNextYear,

--- a/tests/helpers/mock-modules.js
+++ b/tests/helpers/mock-modules.js
@@ -8,6 +8,7 @@ const stubMap = {
   sequelize: path.resolve(__dirname, '../stubs/sequelize.js'),
   uuid: path.resolve(__dirname, '../stubs/uuid.js'),
   exceljs: path.resolve(__dirname, '../stubs/exceljs.js'),
+  winston: path.resolve(__dirname, '../stubs/winston.js'),
 };
 
 module.exports = () => {

--- a/tests/manager.service.test.js
+++ b/tests/manager.service.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const setupModuleMocks = require('./helpers/mock-modules');
+
+const restoreModuleMocks = setupModuleMocks();
+
+const servicePath = path.resolve(__dirname, '../src/services/manager.service.js');
+const modelsPath = path.resolve(__dirname, '../src/models/index.js');
+const loggerPath = path.resolve(__dirname, '../src/utils/logger.js');
+
+const loadService = (overrides = {}) => {
+  delete require.cache[servicePath];
+  delete require.cache[modelsPath];
+  delete require.cache[loggerPath];
+
+  const monthExpression = Symbol('monthExpression');
+  const captured = {};
+
+  const sequelizeStub = {
+    fn: (...args) => (args[0] === 'DATE_FORMAT' ? monthExpression : { fn: args }),
+    col: (value) => ({ col: value }),
+  };
+
+  const ProductStub = {
+    name: 'Product',
+    rawAttributes: { createdAt: { field: 'createdAt' } },
+    findAll: async (options) => {
+      captured.options = options;
+      return overrides.findAllResult || [
+        { month: '2023-01-01T00:00:00.000Z', productCount: '3' },
+        { month: '2023-02-01T00:00:00.000Z', productCount: '1' },
+      ];
+    },
+  };
+
+  require.cache[modelsPath] = {
+    id: modelsPath,
+    filename: modelsPath,
+    loaded: true,
+    exports: {
+      Product: { ...ProductStub, ...(overrides.product || {}) },
+      User: {},
+      Store: {},
+      sequelize: overrides.sequelize || sequelizeStub,
+    },
+  };
+
+  const managerService = require(servicePath);
+
+  const cleanup = () => {
+    delete require.cache[servicePath];
+    delete require.cache[modelsPath];
+    delete require.cache[loggerPath];
+  };
+
+  return { managerService, captured, monthExpression, cleanup };
+};
+
+const { Op } = require('sequelize');
+
+test.after(() => {
+  restoreModuleMocks();
+});
+
+test('getMonthlyProductSummary includes inactive products in counts', async () => {
+  const { managerService, captured, cleanup } = loadService();
+
+  try {
+    const summary = await managerService.getMonthlyProductSummary(2023);
+
+    assert.equal(summary.year, 2023);
+    assert.ok(Array.isArray(summary.monthlyProducts));
+    const january = summary.monthlyProducts.find((entry) => entry.month === 'January');
+    assert.ok(january, 'January entry should exist');
+    assert.equal(january.total, 3, 'January total should reflect active and inactive products');
+
+    const march = summary.monthlyProducts.find((entry) => entry.month === 'March');
+    assert.ok(march, 'March entry should exist');
+    assert.equal(march.total, 0, 'Months without products should return zero total');
+
+    assert.ok(captured.options, 'findAll should be called with options');
+    assert.ok(captured.options.where, 'where clause should be provided');
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(captured.options.where, 'isActive'),
+      false,
+      'isActive filter should not be present',
+    );
+
+    const createdAtFilter = captured.options.where.createdAt;
+    assert.ok(createdAtFilter, 'createdAt filter should be present');
+    assert.ok(createdAtFilter[Op.gte] instanceof Date, 'gte bound should be a date');
+    assert.ok(createdAtFilter[Op.lt] instanceof Date, 'lt bound should be a date');
+  } finally {
+    cleanup();
+  }
+});
+  require.cache[loggerPath] = {
+    id: loggerPath,
+    filename: loggerPath,
+    loaded: true,
+    exports: {
+      info: () => {},
+      error: () => {},
+      warn: () => {},
+    },
+  };
+

--- a/tests/stubs/sequelize.js
+++ b/tests/stubs/sequelize.js
@@ -3,6 +3,7 @@ const Op = {
   iLike: Symbol('iLike'),
   gte: Symbol('gte'),
   lte: Symbol('lte'),
+  lt: Symbol('lt'),
 };
 
 class SequelizeStub {

--- a/tests/stubs/winston.js
+++ b/tests/stubs/winston.js
@@ -1,0 +1,20 @@
+module.exports = {
+  createLogger: () => ({
+    info: () => {},
+    error: () => {},
+    warn: () => {},
+    add: () => {},
+  }),
+  transports: {
+    Console: class {},
+  },
+  format: {
+    combine: (...fns) => fns,
+    timestamp: () => ({}),
+    printf: (fn) => fn,
+    colorize: () => ({}),
+    simple: () => ({}),
+    errors: () => ({}),
+    json: () => ({}),
+  },
+};


### PR DESCRIPTION
## Summary
- remove the active product constraint from the manager monthly summary so all products contribute to the totals
- add a manager service test to cover active and inactive products and provide supporting stubs for the test environment

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da81c84e908326bda6c50aeabfb458