### PR TITLE
Configure Sequelize timezone handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ DB_NAME=enterprise_api_dev
 DB_USERNAME=postgres
 DB_PASSWORD=password
 DB_DIALECT=postgres
+DB_TIMEZONE=+07:00
 
 # JWT
 JWT_SECRET=your-super-secret-jwt-key-here

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,52 +1,60 @@
 const config = require('./index');
 
+const dbTimezone = process.env.DB_TIMEZONE || '+07:00';
+const normalizedDialect = (config.database.dialect || '').toLowerCase();
+const isMySQLDialect = ['mysql', 'mariadb'].includes(normalizedDialect);
+
+const baseDialectOptions = {
+  useUTC: false,
+  ...(isMySQLDialect
+    ? {
+        dateStrings: true,
+        typeCast(field, next) {
+          if (field.type === 'DATETIME' || field.type === 'TIMESTAMP') {
+            return field.string();
+          }
+
+          return next();
+        },
+      }
+    : {}),
+};
+
+const baseDefine = {
+  timestamps: true,
+  paranoid: false,
+  underscored: true,
+};
+
+const baseConfig = {
+  username: config.database.username,
+  password: config.database.password,
+  host: config.database.host,
+  port: config.database.port,
+  dialect: config.database.dialect,
+  logging: false,
+  timezone: dbTimezone,
+  dialectOptions: baseDialectOptions,
+  define: baseDefine,
+};
+
 module.exports = {
   development: {
-    username: config.database.username,
-    password: config.database.password,
+    ...baseConfig,
     database: config.database.database,
-    host: config.database.host,
-    port: config.database.port,
-    dialect: config.database.dialect,
-    logging: false,
-    define: {
-      timestamps: true,
-      paranoid: false,
-      underscored: true,
-    },
   },
   test: {
-    username: config.database.username,
-    password: config.database.password,
+    ...baseConfig,
     database: `${config.database.database}_test`,
-    host: config.database.host,
-    port: config.database.port,
-    dialect: config.database.dialect,
-    logging: false,
-    define: {
-      timestamps: true,
-      paranoid: false,
-      underscored: true,
-    },
   },
   production: {
-    username: config.database.username,
-    password: config.database.password,
+    ...baseConfig,
     database: config.database.database,
-    host: config.database.host,
-    port: config.database.port,
-    dialect: config.database.dialect,
-    logging: false,
     pool: {
       max: 5,
       min: 0,
       acquire: 30000,
       idle: 10000,
-    },
-    define: {
-      timestamps: true,
-      paranoid: false,
-      underscored: true,
     },
   },
 };


### PR DESCRIPTION
## Summary
- add shared timezone configuration for all Sequelize environments, including MySQL-specific casting when needed
- expose DB_TIMEZONE variable in the example environment file for deployment configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da852210c48326954b3ce6efcff94b