### PR TITLE
Include inactive products in dashboard totals

### DIFF
--- a/src/services/manager.service.js
+++ b/src/services/manager.service.js
@@ -9,7 +9,7 @@ class ManagerService {
         Store.count({ where: { isActive: true } }),
         User.count({ where: { role: 'SUPERVISOR', isActive: true } }),
         User.count({ where: { role: 'SALES', isActive: true } }),
-        Product.count({ where: { isActive: true } }),
+        Product.count(),
         Store.findAll({
             attributes: [
               'id',


### PR DESCRIPTION
## Summary
- update the manager dashboard metrics to include inactive products in total product counts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db7a66c7988326be739b6f5c063671