### PR TITLE
Use supervisor phone for Excel exports

### DIFF
--- a/src/controllers/manager.controller.js
+++ b/src/controllers/manager.controller.js
@@ -184,6 +184,17 @@ const getProducts = async (req, res, next) => {
       attributes: ['id', 'name', 'phone', 'supervisorId'],
     };
 
+    if (exporting) {
+      creatorInclude.include = [
+        {
+          model: User,
+          as: 'supervisor',
+          attributes: ['id', 'name', 'phone'],
+          required: false,
+        },
+      ];
+    }
+
     if (req.query.supervisor_id) {
       creatorInclude.where = { supervisorId: req.query.supervisor_id };
     }

--- a/src/controllers/sales.controller.js
+++ b/src/controllers/sales.controller.js
@@ -124,20 +124,32 @@ const getProducts = async (req, res, next) => {
     const exporting = req.query.export === 'excel';
     const where = buildProductFilters(req.query, req.user);
 
-    const baseOptions = {
-      where,
-      include: [
-        {
-          model: Store,
-          as: 'store',
-          attributes: ['id', 'name', 'address', 'phone'],
-        },
+    const storeInclude = {
+      model: Store,
+      as: 'store',
+      attributes: ['id', 'name', 'address', 'phone'],
+    };
+
+    const creatorInclude = {
+      model: User,
+      as: 'creator',
+      attributes: ['id', 'name', 'phone', 'supervisorId'],
+    };
+
+    if (exporting) {
+      creatorInclude.include = [
         {
           model: User,
-          as: 'creator',
+          as: 'supervisor',
           attributes: ['id', 'name', 'phone'],
+          required: false,
         },
-      ],
+      ];
+    }
+
+    const baseOptions = {
+      where,
+      include: [storeInclude, creatorInclude],
       distinct: true,
     };
 

--- a/src/controllers/supervisor.controller.js
+++ b/src/controllers/supervisor.controller.js
@@ -74,6 +74,17 @@ const getProducts = async (req, res, next) => {
       attributes: ['id', 'name', 'phone', 'supervisorId'],
     };
 
+    if (exporting) {
+      creatorInclude.include = [
+        {
+          model: User,
+          as: 'supervisor',
+          attributes: ['id', 'name', 'phone'],
+          required: false,
+        },
+      ];
+    }
+
     if (req.query.supervisor_id) {
       creatorInclude.where = { supervisorId: req.query.supervisor_id };
     }

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -35,7 +35,7 @@ const streamProductsXlsx = async (res, products, filename = 'products.xlsx') => 
       priceWarranty: product.priceWarranty !== undefined && product.priceWarranty !== null ? Number(product.priceWarranty) : '',
       status: deriveStatus(product.isActive, product.createdAt), // <-- status terhitung
       storeName: product.store?.name || '',
-      storePhone: product.store?.phone || '',
+      storePhone: product.creator?.supervisor?.phone ?? '',
       creatorName: product.creator?.name || '',
       creatorPhone: product.creator?.phone || '',
       createdAt: formatDateToDDMMYYYY(product.createdAt),

--- a/tests/excel.utils.test.js
+++ b/tests/excel.utils.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const setupModuleMocks = require('./helpers/mock-modules');
+
+const restoreModuleMocks = setupModuleMocks();
+
+const ExcelJS = require('exceljs');
+const { streamProductsXlsx } = require('../src/utils/excel');
+
+test.after(() => {
+  restoreModuleMocks();
+});
+
+test('streamProductsXlsx uses supervisor phone number for storePhone column', async () => {
+  const res = {
+    setHeader: () => {},
+    end: () => {},
+  };
+
+  const products = [
+    {
+      name: 'Sample Product',
+      code: 'PRD-001',
+      price: 10000,
+      priceWarranty: 15000,
+      isActive: true,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      store: {
+        name: 'Main Store',
+        phone: '0800000000',
+      },
+      creator: {
+        name: 'Sales User',
+        phone: '0811111111',
+        supervisor: {
+          id: 'supervisor-1',
+          name: 'Supervisor User',
+          phone: '0822222222',
+        },
+      },
+    },
+  ];
+
+  await streamProductsXlsx(res, products, 'products.xlsx');
+
+  const workbook = ExcelJS.__getLastWorkbook();
+  assert.ok(workbook, 'Workbook instance should be captured');
+
+  const worksheet = workbook.worksheets[0];
+  assert.ok(worksheet, 'Worksheet should be created');
+
+  assert.equal(worksheet.rows.length, 1);
+  const [firstRow] = worksheet.rows;
+  assert.equal(firstRow.storePhone, '0822222222');
+});

--- a/tests/stubs/exceljs.js
+++ b/tests/stubs/exceljs.js
@@ -1,6 +1,7 @@
 class Worksheet {
   constructor() {
     this.columns = [];
+    this.rows = [];
   }
 
   getRow() {
@@ -10,7 +11,9 @@ class Worksheet {
     };
   }
 
-  addRow() {}
+  addRow(data) {
+    this.rows.push(data);
+  }
 }
 
 class Workbook {
@@ -19,6 +22,7 @@ class Workbook {
     this.xlsx = {
       write: async () => {},
     };
+    Workbook.__lastWorkbook = this;
   }
 
   addWorksheet() {
@@ -30,4 +34,5 @@ class Workbook {
 
 module.exports = {
   Workbook,
+  __getLastWorkbook: () => Workbook.__lastWorkbook,
 };


### PR DESCRIPTION
## Summary
- update Excel export to populate the storePhone column with the supervisor phone number
- eager load supervisor data when exporting products so the phone number is available
- extend the Excel utility test and stub to cover the supervisor phone behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68db7d4ca1ec832689b67f20b9643557