### PR TITLE
Fix product filters for MySQL case-insensitive search

### DIFF
--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -1,15 +1,30 @@
-const { Op } = require('sequelize');
+const { Op, fn, col, where: buildWhere } = require('sequelize');
+
+const buildCaseInsensitiveLike = (columnPath, value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalizedValue = value.toLowerCase();
+  const likeValue = `%${normalizedValue}%`;
+
+  return buildWhere(fn('LOWER', col(columnPath)), { [Op.like]: likeValue });
+};
 
 const buildProductFilters = (query, user, sequelize) => {
   const where = {};
-  
+
   // Text search in name, code, notes
   if (query.q) {
-    where[Op.or] = [
-      { name: { [Op.iLike]: `%${query.q}%` } },
-      { code: { [Op.iLike]: `%${query.q}%` } },
-      { notes: { [Op.iLike]: `%${query.q}%` } },
-    ];
+    const caseInsensitiveMatchers = [
+      buildCaseInsensitiveLike('name', query.q),
+      buildCaseInsensitiveLike('code', query.q),
+      buildCaseInsensitiveLike('notes', query.q),
+    ].filter(Boolean);
+
+    if (caseInsensitiveMatchers.length > 0) {
+      where[Op.or] = caseInsensitiveMatchers;
+    }
   }
   
   // Exact code match
@@ -25,7 +40,10 @@ const buildProductFilters = (query, user, sequelize) => {
   if (typeof query.store_name === 'string') {
     const trimmedStoreName = query.store_name.trim();
     if (trimmedStoreName) {
-      where['$store.name$'] = { [Op.iLike]: `%${trimmedStoreName}%` };
+      const storeNameMatcher = buildCaseInsensitiveLike('store.name', trimmedStoreName);
+      if (storeNameMatcher) {
+        where['$store.name$'] = storeNameMatcher;
+      }
     }
   }
   
@@ -80,4 +98,5 @@ const buildProductFilters = (query, user, sequelize) => {
 
 module.exports = {
   buildProductFilters,
+  buildCaseInsensitiveLike,
 };

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -4,7 +4,7 @@ const setupModuleMocks = require('./helpers/mock-modules');
 
 const restoreModuleMocks = setupModuleMocks();
 
-const { Op } = require('sequelize');
+const { Op, fn, col, where } = require('sequelize');
 const { buildProductFilters } = require('../src/utils/filters');
 
 const baseUser = { role: 'MANAGER' };
@@ -16,11 +16,29 @@ test.after(() => {
 test('buildProductFilters adds store name condition when provided', () => {
   const filters = buildProductFilters({ store_name: ' Central ' }, baseUser);
 
-  assert.deepEqual(filters['$store.name$'], { [Op.iLike]: '%Central%' });
+  const expectedMatcher = where(
+    fn('LOWER', col('store.name')),
+    { [Op.like]: '%central%' },
+  );
+
+  assert.deepEqual(filters['$store.name$'], expectedMatcher);
 });
 
 test('buildProductFilters ignores blank store name', () => {
   const filters = buildProductFilters({ store_name: '   ' }, baseUser);
 
   assert.equal(filters['$store.name$'], undefined);
+});
+
+test('buildProductFilters creates case-insensitive search for q parameter', () => {
+  const filters = buildProductFilters({ q: 'TeSt' }, baseUser);
+
+  assert.ok(Array.isArray(filters[Op.or]));
+  const [nameMatcher] = filters[Op.or];
+  const expectedMatcher = where(
+    fn('LOWER', col('name')),
+    { [Op.like]: '%test%' },
+  );
+
+  assert.deepEqual(nameMatcher, expectedMatcher);
 });

--- a/tests/stubs/sequelize.js
+++ b/tests/stubs/sequelize.js
@@ -1,10 +1,29 @@
 const Op = {
   or: Symbol('or'),
+  and: Symbol('and'),
+  like: Symbol('like'),
   iLike: Symbol('iLike'),
   gte: Symbol('gte'),
   lte: Symbol('lte'),
   lt: Symbol('lt'),
 };
+
+const fn = (name, ...args) => ({
+  type: 'fn',
+  name,
+  args,
+});
+
+const col = (name) => ({
+  type: 'col',
+  name,
+});
+
+const where = (lhs, rhs) => ({
+  type: 'where',
+  lhs,
+  rhs,
+});
 
 class SequelizeStub {
   constructor() {}
@@ -22,3 +41,6 @@ module.exports = SequelizeStub;
 module.exports.Sequelize = SequelizeStub;
 module.exports.Op = Op;
 module.exports.DataTypes = DataTypes;
+module.exports.fn = fn;
+module.exports.col = col;
+module.exports.where = where;


### PR DESCRIPTION
## Summary
- replace Postgres-specific ILIKE filters with case-insensitive LIKE expressions built with LOWER columns
- reuse the new helper in the manager product export include to avoid emitting ILIKE
- update filter and manager controller tests (plus Sequelize stub) to cover case-insensitive matching

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db83c3341483269134c3fb618ac87a