### PR TITLE
Normalize created_at date filters

### DIFF
--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -50,12 +50,27 @@ const buildProductFilters = (query, user, sequelize) => {
   // Date range filters
   if (query.created_at_from || query.created_at_to) {
     const dateFilter = {};
+
     if (query.created_at_from) {
-      dateFilter[Op.gte] = query.created_at_from;
+      const fromDate = new Date(query.created_at_from);
+      if (!Number.isNaN(fromDate.getTime())) {
+        fromDate.setHours(0, 0, 1, 0);
+        dateFilter[Op.gte] = fromDate;
+      } else {
+        dateFilter[Op.gte] = query.created_at_from;
+      }
     }
+
     if (query.created_at_to) {
-      dateFilter[Op.lte] = query.created_at_to;
+      const toDate = new Date(query.created_at_to);
+      if (!Number.isNaN(toDate.getTime())) {
+        toDate.setHours(23, 59, 59, 999);
+        dateFilter[Op.lte] = toDate;
+      } else {
+        dateFilter[Op.lte] = query.created_at_to;
+      }
     }
+
     where.createdAt = dateFilter;
   }
   

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -42,3 +42,27 @@ test('buildProductFilters creates case-insensitive search for q parameter', () =
 
   assert.deepEqual(nameMatcher, expectedMatcher);
 });
+
+test('buildProductFilters normalizes created_at_from to start of day', () => {
+  const filters = buildProductFilters({ created_at_from: '2024-01-15' }, baseUser);
+
+  const fromFilter = filters.createdAt[Op.gte];
+
+  assert.ok(fromFilter instanceof Date);
+  assert.equal(fromFilter.getHours(), 0);
+  assert.equal(fromFilter.getMinutes(), 0);
+  assert.equal(fromFilter.getSeconds(), 1);
+  assert.equal(fromFilter.getMilliseconds(), 0);
+});
+
+test('buildProductFilters normalizes created_at_to to end of day', () => {
+  const filters = buildProductFilters({ created_at_to: '2024-01-15' }, baseUser);
+
+  const toFilter = filters.createdAt[Op.lte];
+
+  assert.ok(toFilter instanceof Date);
+  assert.equal(toFilter.getHours(), 23);
+  assert.equal(toFilter.getMinutes(), 59);
+  assert.equal(toFilter.getSeconds(), 59);
+  assert.equal(toFilter.getMilliseconds(), 999);
+});


### PR DESCRIPTION
## Summary
- normalize product created_at filters to use day start/end times when valid dates are provided
- add unit tests covering the adjusted date bounds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db9144f204832690c25b07648fdb7a