### PR TITLE
Add supervisor product deletion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - `DELETE /supervisors/sales/:id` - Delete sales user
 - `GET /supervisors/sales` - List sales users in supervisor's store
 - `GET /supervisors/products` - List store products (with filters, pagination, Excel export)
+- `DELETE /supervisors/products/:id` - Delete product from supervisor's store
 
 ### Sales Routes
 - `POST /sales/products` - Create product

--- a/src/controllers/supervisor.controller.js
+++ b/src/controllers/supervisor.controller.js
@@ -40,12 +40,28 @@ const deleteSalesUser = async (req, res, next) => {
   try {
     const { id } = req.params;
     const supervisorId = req.user.sub;
-    
+
     const result = await supervisorService.deleteSalesUser(id, supervisorId);
     res.json(response.success('Sales user deleted successfully', result));
   } catch (error) {
     if (error.message === 'Sales user not found') {
       return res.status(404).json(response.error('Sales user not found'));
+    }
+    next(error);
+  }
+};
+
+const deleteProduct = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const supervisorId = req.user.sub;
+    const storeId = req.user.store_id;
+
+    const result = await supervisorService.deleteProduct(id, supervisorId, storeId);
+    res.json(response.success('Product deleted successfully', result));
+  } catch (error) {
+    if (error.message === 'Product not found') {
+      return res.status(404).json(response.error('Product not found'));
     }
     next(error);
   }
@@ -132,6 +148,7 @@ module.exports = {
   createSalesValidation,
   createSalesUser,
   deleteSalesUser,
+  deleteProduct,
   getSalesUsers,
   getProducts,
   handleValidationErrors,

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -368,6 +368,28 @@ const options = {
             },
           },
         },
+        SupervisorDeleteProductResponse: {
+          type: 'object',
+          properties: {
+            success: {
+              type: 'boolean',
+              example: true,
+            },
+            message: {
+              type: 'string',
+              example: 'Product deleted successfully',
+            },
+            data: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string',
+                  example: 'Product deleted successfully',
+                },
+              },
+            },
+          },
+        },
         ErrorResponse: {
           type: 'object',
           properties: {

--- a/src/routes/supervisor.routes.js
+++ b/src/routes/supervisor.routes.js
@@ -5,6 +5,7 @@ const {
   createSalesValidation,
   createSalesUser,
   deleteSalesUser,
+  deleteProduct,
   getSalesUsers,
   getProducts,
   handleValidationErrors,
@@ -114,5 +115,36 @@ router.get('/sales', getSalesUsers);
  *               format: binary
  */
 router.get('/products', getProducts);
+
+/**
+ * @swagger
+ * /api/supervisors/products/{id}:
+ *   delete:
+ *     summary: Delete a product from the supervisor's store
+ *     tags: [Supervisor]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Product deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SupervisorDeleteProductResponse'
+ *       404:
+ *         description: Product not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.delete('/products/:id', deleteProduct);
 
 module.exports = router;

--- a/src/services/supervisor.service.js
+++ b/src/services/supervisor.service.js
@@ -27,8 +27,8 @@ class SupervisorService {
   async deleteSalesUser(salesUserId, supervisorId) {
     try {
       const salesUser = await User.findOne({
-        where: { 
-          id: salesUserId, 
+        where: {
+          id: salesUserId,
           role: 'SALES',
           supervisorId,
         },
@@ -56,7 +56,7 @@ class SupervisorService {
   async getSalesUsers(supervisorId, storeId) {
     try {
       const salesUsers = await User.findAll({
-        where: { 
+        where: {
           role: 'SALES',
           supervisorId,
           storeId,
@@ -73,6 +73,35 @@ class SupervisorService {
       return salesUsers;
     } catch (error) {
       logger.error('Failed to get sales users:', error);
+      throw error;
+    }
+  }
+
+  async deleteProduct(productId, supervisorId, storeId) {
+    try {
+      const product = await Product.findOne({
+        where: {
+          id: productId,
+          storeId,
+        },
+      });
+
+      if (!product) {
+        throw new Error('Product not found');
+      }
+
+      await product.destroy();
+
+      logger.info('Product deleted by supervisor:', {
+        productId,
+        supervisorId,
+        storeId,
+        code: product.code,
+      });
+
+      return { message: 'Product deleted successfully' };
+    } catch (error) {
+      logger.error('Failed to delete product:', error);
       throw error;
     }
   }

--- a/tests/supervisor.controller.test.js
+++ b/tests/supervisor.controller.test.js
@@ -1,0 +1,165 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const setupModuleMocks = require('./helpers/mock-modules');
+
+const restoreModuleMocks = setupModuleMocks();
+
+test.after(() => {
+  restoreModuleMocks();
+});
+
+const controllerPath = path.resolve(__dirname, '../src/controllers/supervisor.controller.js');
+const servicePath = path.resolve(__dirname, '../src/services/supervisor.service.js');
+const modelsPath = path.resolve(__dirname, '../src/models/index.js');
+const loggerPath = path.resolve(__dirname, '../src/utils/logger.js');
+const excelPath = path.resolve(__dirname, '../src/utils/excel.js');
+
+const loadController = (serviceMock) => {
+  delete require.cache[controllerPath];
+  delete require.cache[servicePath];
+  delete require.cache[modelsPath];
+  delete require.cache[loggerPath];
+  delete require.cache[excelPath];
+
+  require.cache[modelsPath] = {
+    id: modelsPath,
+    filename: modelsPath,
+    loaded: true,
+    exports: {
+      Product: {},
+      Store: {},
+      User: {},
+    },
+  };
+
+  require.cache[loggerPath] = {
+    id: loggerPath,
+    filename: loggerPath,
+    loaded: true,
+    exports: {
+      info: () => {},
+      error: () => {},
+    },
+  };
+
+  require.cache[excelPath] = {
+    id: excelPath,
+    filename: excelPath,
+    loaded: true,
+    exports: {
+      streamProductsXlsx: async () => {},
+    },
+  };
+
+  require.cache[servicePath] = {
+    id: servicePath,
+    filename: servicePath,
+    loaded: true,
+    exports: {
+      createSalesUser: async () => undefined,
+      deleteSalesUser: async () => undefined,
+      getSalesUsers: async () => undefined,
+      getProducts: async () => undefined,
+      deleteProduct: async () => undefined,
+      ...serviceMock,
+    },
+  };
+
+  const controller = require(controllerPath);
+
+  const cleanup = () => {
+    delete require.cache[controllerPath];
+    delete require.cache[servicePath];
+    delete require.cache[modelsPath];
+    delete require.cache[loggerPath];
+    delete require.cache[excelPath];
+  };
+
+  return { controller, cleanup };
+};
+
+test('deleteProduct controller returns success response when deletion succeeds', async () => {
+  const resultPayload = { message: 'Product deleted successfully' };
+  const { controller, cleanup } = loadController({
+    deleteProduct: async () => resultPayload,
+  });
+
+  try {
+    const req = {
+      params: { id: 'product-123' },
+      user: { sub: 'supervisor-1', store_id: 'store-1' },
+    };
+
+    let statusCode;
+    let jsonPayload;
+    const res = {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    let nextCalled = false;
+    const next = () => {
+      nextCalled = true;
+    };
+
+    await controller.deleteProduct(req, res, next);
+
+    assert.equal(statusCode, undefined);
+    assert.ok(jsonPayload.success);
+    assert.equal(jsonPayload.message, 'Product deleted successfully');
+    assert.deepEqual(jsonPayload.data, resultPayload);
+    assert.equal(nextCalled, false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('deleteProduct controller converts missing product to 404 response', async () => {
+  const { controller, cleanup } = loadController({
+    deleteProduct: async () => {
+      const error = new Error('Product not found');
+      throw error;
+    },
+  });
+
+  try {
+    const req = {
+      params: { id: 'product-missing' },
+      user: { sub: 'supervisor-1', store_id: 'store-1' },
+    };
+
+    let statusCode;
+    let jsonPayload;
+    const res = {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        jsonPayload = payload;
+        return this;
+      },
+    };
+
+    let nextCalled = false;
+    const next = () => {
+      nextCalled = true;
+    };
+
+    await controller.deleteProduct(req, res, next);
+
+    assert.equal(statusCode, 404);
+    assert.ok(!jsonPayload.success);
+    assert.equal(jsonPayload.message, 'Product not found');
+    assert.equal(nextCalled, false);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/supervisor.service.test.js
+++ b/tests/supervisor.service.test.js
@@ -1,0 +1,96 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const setupModuleMocks = require('./helpers/mock-modules');
+
+const restoreModuleMocks = setupModuleMocks();
+
+test.after(() => {
+  restoreModuleMocks();
+});
+
+const servicePath = path.resolve(__dirname, '../src/services/supervisor.service.js');
+const modelsPath = path.resolve(__dirname, '../src/models/index.js');
+const loggerPath = path.resolve(__dirname, '../src/utils/logger.js');
+
+const withServiceMocks = (productFindOne) => {
+  delete require.cache[servicePath];
+  delete require.cache[modelsPath];
+  delete require.cache[loggerPath];
+
+  const infoLogs = [];
+  const errorLogs = [];
+
+  require.cache[modelsPath] = {
+    id: modelsPath,
+    filename: modelsPath,
+    loaded: true,
+    exports: {
+      User: {},
+      Store: {},
+      Product: {
+        findOne: productFindOne,
+      },
+    },
+  };
+
+  require.cache[loggerPath] = {
+    id: loggerPath,
+    filename: loggerPath,
+    loaded: true,
+    exports: {
+      info: (...args) => infoLogs.push(args),
+      error: (...args) => errorLogs.push(args),
+    },
+  };
+
+  const supervisorService = require(servicePath);
+
+  const cleanup = () => {
+    delete require.cache[servicePath];
+    delete require.cache[modelsPath];
+    delete require.cache[loggerPath];
+  };
+
+  return { supervisorService, infoLogs, errorLogs, cleanup };
+};
+
+test('deleteProduct removes product and logs the action', async () => {
+  const destroyed = { value: false };
+  const productRecord = {
+    id: 'product-123',
+    code: 'P-123',
+    destroy: async () => {
+      destroyed.value = true;
+    },
+  };
+
+  const { supervisorService, infoLogs, errorLogs, cleanup } = withServiceMocks(async () => productRecord);
+
+  try {
+    const result = await supervisorService.deleteProduct('product-123', 'supervisor-1', 'store-1');
+
+    assert.deepEqual(result, { message: 'Product deleted successfully' });
+    assert.equal(destroyed.value, true);
+    assert.equal(errorLogs.length, 0);
+    assert.ok(infoLogs.length > 0);
+    assert.equal(infoLogs[0][0], 'Product deleted by supervisor:');
+  } finally {
+    cleanup();
+  }
+});
+
+test('deleteProduct throws when product is not found and logs the error', async () => {
+  const { supervisorService, errorLogs, cleanup } = withServiceMocks(async () => null);
+
+  try {
+    await assert.rejects(
+      supervisorService.deleteProduct('missing', 'supervisor-1', 'store-1'),
+      /Product not found/,
+    );
+    assert.ok(errorLogs.length > 0);
+    assert.equal(errorLogs[0][0], 'Failed to delete product:');
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- add supervisor-side product deletion service logic, controller handler, and route with Swagger documentation
- document the new supervisor product delete endpoint and add coverage tests

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68dc9fe6ade88326989a33ecdb4a9e9e