### PR TITLE
Fix customer phone column used in product search

### DIFF
--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -75,7 +75,7 @@ const options = {
           schema: {
             type: 'string',
           },
-          description: 'Search in name, code, and notes',
+          description: 'Search in name, code, customer phone, and notes',
         },
         codeParam: {
           in: 'query',

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -23,6 +23,7 @@ const buildProductFilters = (query, user, sequelize) => {
     const caseInsensitiveMatchers = [
       buildCaseInsensitiveLike('Product.name', query.q),
       buildCaseInsensitiveLike('Product.code', query.q),
+      buildCaseInsensitiveLike('Product.customer_phone', query.q),
       buildCaseInsensitiveLike('Product.notes', query.q),
     ].filter(Boolean);
 


### PR DESCRIPTION
## Summary
- update product search filter to query the correct `customer_phone` column

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69329e8d023c8326a5645f2ba787c6da)